### PR TITLE
Organize engine modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+bin/
+obj/
+*.user
+*.rsuser
+*.suo
+*.userprefs
+.DS_Store
+.vscode/

--- a/src/Axioms/AxiomConflictMediator.cs
+++ b/src/Axioms/AxiomConflictMediator.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+
+namespace SymbolicTrading.Axioms
+{
+    public class AxiomConflictMediator
+    {
+        private readonly Queue<AxiomEvent> _queue = new();
+        public event Action<AxiomEvent>? OnResolved;
+
+        public void RegisterAxiom(AxiomEvent axiom)
+        {
+            _queue.Enqueue(axiom);
+        }
+
+        public void ProcessQueue()
+        {
+            while (_queue.Count > 0)
+            {
+                var ax = _queue.Dequeue();
+                OnResolved?.Invoke(ax);
+            }
+        }
+    }
+}

--- a/src/Axioms/AxiomEvent.cs
+++ b/src/Axioms/AxiomEvent.cs
@@ -1,0 +1,14 @@
+namespace SymbolicTrading.Axioms
+{
+    public class AxiomEvent
+    {
+        public string Id { get; }
+        public string? Data { get; }
+
+        public AxiomEvent(string id, string? data = null)
+        {
+            Id = id;
+            Data = data;
+        }
+    }
+}

--- a/src/Axioms/AxiomRegistry.cs
+++ b/src/Axioms/AxiomRegistry.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+
+namespace SymbolicTrading.Axioms
+{
+    public class AxiomRegistry
+    {
+        private readonly List<string> _axioms = new();
+
+        public void InitializeDefaultAxioms()
+        {
+            // Placeholder for actual axiom initialization
+            _axioms.Add("AXIOM⇌000");
+        }
+    }
+}

--- a/src/Axioms/ReflexGlyphCollapseEngine.cs
+++ b/src/Axioms/ReflexGlyphCollapseEngine.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using SymbolicTrading.Signals;
+
+namespace SymbolicTrading.Axioms
+{
+    public class ReflexGlyphCollapseEngine
+    {
+        private readonly AxiomRegistry _registry;
+        private readonly List<AxiomEvent> _buffer = new();
+
+        public ReflexGlyphCollapseEngine(AxiomRegistry registry)
+        {
+            _registry = registry;
+        }
+
+        public void ProcessGlyph(GlyphPhase glyph)
+        {
+            // Placeholder logic generating a trivial event
+            _buffer.Add(new AxiomEvent("AXIOM⇌000"));
+        }
+
+        public IEnumerable<AxiomEvent> EmitLatestEvents()
+        {
+            var events = _buffer.ToArray();
+            _buffer.Clear();
+            return events;
+        }
+    }
+}

--- a/src/Engine/ThinkingEngine.cs
+++ b/src/Engine/ThinkingEngine.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.Reactive.Subjects;
+using System.Reactive.Linq;
+using SymbolicTrading.Axioms;
+using SymbolicTrading.Signals;
+
+namespace SymbolicTrading.Engine
+{
+    /// <summary>
+    /// Central engine responsible for translating market ticks into glyph phases and resolved axioms.
+    /// <para>Integrates with:</para>
+    /// <list type="bullet">
+    /// <item><description><c>PulseRing</c> invokes <see cref="OnMarketTick"/> on market updates.</description></item>
+    /// <item><description><c>Strategy</c> modules observe <see cref="GlyphStream"/> and <see cref="AxiomStream"/>.</description></item>
+    /// <item><description><c>Capsules</c> persist events from <see cref="AxiomStream"/>.</description></item>
+    /// </list>
+    /// </summary>
+    public class ThinkingEngine : IDisposable
+    {
+        // Publishes the generated glyph phases to observers
+        private readonly Subject<GlyphPhase> _glyphSubject = new();
+        // Publishes resolved axioms after conflict mediation
+        private readonly Subject<AxiomEvent> _axiomSubject = new();
+        // Handles glyph collapse logic using the registered axioms
+        private readonly ReflexGlyphCollapseEngine _collapseEngine;
+        // Mediates conflicts among emitted axioms before publishing
+        private readonly AxiomConflictMediator _conflictMediator;
+        // Translates entropy/drift pairs into symbol identifiers
+        private readonly SymbolMapper _symbolMapper = new();
+
+        /// <summary>Observable stream of generated glyph phases.</summary>
+        public IObservable<GlyphPhase> GlyphStream => _glyphSubject.AsObservable();
+        /// <summary>Observable stream of resolved axiom events.</summary>
+        public IObservable<AxiomEvent> AxiomStream => _axiomSubject.AsObservable();
+
+        public ThinkingEngine()
+        {
+            var axiomRegistry = new AxiomRegistry();
+            axiomRegistry.InitializeDefaultAxioms();
+
+            _collapseEngine = new ReflexGlyphCollapseEngine(axiomRegistry);
+            _conflictMediator = new AxiomConflictMediator();
+
+            // Forward resolved axioms from mediator to public stream
+            _conflictMediator.OnResolved += ax => _axiomSubject.OnNext(ax);
+        }
+
+        /// <summary>
+        /// Primary entry point for market ticks. Converts the raw values to a
+        /// <see cref="GlyphPhase"/> and processes it through the collapse and
+        /// mediation pipelines.
+        /// </summary>
+        public void OnMarketTick(double entropy, double drift, DateTime timestamp)
+        {
+            string symbol = _symbolMapper.Map(entropy, drift);
+            var glyph = new GlyphPhase(symbol, entropy, drift, timestamp);
+
+            _glyphSubject.OnNext(glyph);
+            _collapseEngine.ProcessGlyph(glyph);
+
+            foreach (var axiom in _collapseEngine.EmitLatestEvents())
+            {
+                _conflictMediator.RegisterAxiom(axiom);
+            }
+            _conflictMediator.ProcessQueue();
+        }
+
+        public void Dispose()
+        {
+            _glyphSubject?.Dispose();
+            _axiomSubject?.Dispose();
+        }
+    }
+}

--- a/src/QuantumCollapseTrader.csproj
+++ b/src/QuantumCollapseTrader.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+  <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Reactive" Version="5.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/Signals/GlyphPhase.cs
+++ b/src/Signals/GlyphPhase.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace SymbolicTrading.Signals
+{
+    public class GlyphPhase
+    {
+        public string Symbol { get; }
+        public double Entropy { get; }
+        public double Drift { get; }
+        public DateTime Timestamp { get; }
+
+        public GlyphPhase(string symbol, double entropy, double drift, DateTime timestamp)
+        {
+            Symbol = symbol;
+            Entropy = entropy;
+            Drift = drift;
+            Timestamp = timestamp;
+        }
+    }
+}

--- a/src/Signals/SymbolMapper.cs
+++ b/src/Signals/SymbolMapper.cs
@@ -1,0 +1,11 @@
+namespace SymbolicTrading.Signals
+{
+    public class SymbolMapper
+    {
+        public string Map(double entropy, double drift)
+        {
+            // Simple mapping based on entropy threshold
+            return entropy > 0.5 ? "HIGH" : "LOW";
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- move SymbolicTrading engine files into top-level src folders
- rename class library project to `QuantumCollapseTrader`
- annotate `ThinkingEngine` with module integration notes

## Testing
- `dotnet build src/QuantumCollapseTrader.csproj -c Release` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6869af16b63c8320be5b90a66b6817b4