### PR TITLE
Add QuantumCollapseTrader modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Ignore build artifacts
+bin/
+obj/
+*.user
+*.suo
+*.userprefs
+*.dll
+*.pdb
+*.cache
+*.ide

--- a/QuantumCollapseTrader/QuantumCollapseTrader.csproj
+++ b/QuantumCollapseTrader/QuantumCollapseTrader.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/QuantumCollapseTrader/src/AxiomCollapseThreshold.cs
+++ b/QuantumCollapseTrader/src/AxiomCollapseThreshold.cs
@@ -1,0 +1,12 @@
+namespace SymbolicTrading.Axioms
+{
+    // Placeholder implementation of collapse threshold axiom.
+    public class AxiomCollapseThreshold : IAxiom
+    {
+        public bool Apply(List<GlyphPhase> history, GlyphPhase current, out AxiomEvent evt)
+        {
+            evt = new AxiomEvent();
+            return false;
+        }
+    }
+}

--- a/QuantumCollapseTrader/src/AxiomEvent.cs
+++ b/QuantumCollapseTrader/src/AxiomEvent.cs
@@ -1,0 +1,7 @@
+namespace SymbolicTrading.Axioms
+{
+    // Event produced when an axiom triggers during glyph processing.
+    public class AxiomEvent
+    {
+    }
+}

--- a/QuantumCollapseTrader/src/AxiomQuantumEntanglement.cs
+++ b/QuantumCollapseTrader/src/AxiomQuantumEntanglement.cs
@@ -1,0 +1,12 @@
+namespace SymbolicTrading.Axioms
+{
+    // Placeholder axiom representing quantum entanglement interactions.
+    public class AxiomQuantumEntanglement : IAxiom
+    {
+        public bool Apply(List<GlyphPhase> history, GlyphPhase current, out AxiomEvent evt)
+        {
+            evt = new AxiomEvent();
+            return false;
+        }
+    }
+}

--- a/QuantumCollapseTrader/src/AxiomSigilDescent.cs
+++ b/QuantumCollapseTrader/src/AxiomSigilDescent.cs
@@ -1,0 +1,12 @@
+namespace SymbolicTrading.Axioms
+{
+    // Placeholder axiom representing sigil descent processing.
+    public class AxiomSigilDescent : IAxiom
+    {
+        public bool Apply(List<GlyphPhase> history, GlyphPhase current, out AxiomEvent evt)
+        {
+            evt = new AxiomEvent();
+            return false;
+        }
+    }
+}

--- a/QuantumCollapseTrader/src/AxiomXORFusion.cs
+++ b/QuantumCollapseTrader/src/AxiomXORFusion.cs
@@ -1,0 +1,12 @@
+namespace SymbolicTrading.Axioms
+{
+    // Placeholder XOR fusion axiom.
+    public class AxiomXORFusion : IAxiom
+    {
+        public bool Apply(List<GlyphPhase> history, GlyphPhase current, out AxiomEvent evt)
+        {
+            evt = new AxiomEvent();
+            return false;
+        }
+    }
+}

--- a/QuantumCollapseTrader/src/GlyphPhase.cs
+++ b/QuantumCollapseTrader/src/GlyphPhase.cs
@@ -1,0 +1,7 @@
+namespace SymbolicTrading.Axioms
+{
+    // Represents a unit of symbolic glyph input processed by the engine.
+    public class GlyphPhase
+    {
+    }
+}

--- a/QuantumCollapseTrader/src/IAxiom.cs
+++ b/QuantumCollapseTrader/src/IAxiom.cs
@@ -1,0 +1,8 @@
+namespace SymbolicTrading.Axioms
+{
+    // Defines an axiom that can be applied to glyph phases.
+    public interface IAxiom
+    {
+        bool Apply(List<GlyphPhase> history, GlyphPhase current, out AxiomEvent evt);
+    }
+}

--- a/QuantumCollapseTrader/src/Modules/AxiomRegistry.cs
+++ b/QuantumCollapseTrader/src/Modules/AxiomRegistry.cs
@@ -1,0 +1,20 @@
+namespace SymbolicTrading.Axioms
+{
+    // Maintains a list of axioms used throughout the glyph processing pipeline.
+    // Provides registration and default initialization for the engine.
+    public class AxiomRegistry
+    {
+        private readonly List<IAxiom> _axioms = new();
+
+        public void Register(IAxiom axiom) => _axioms.Add(axiom);
+        public IReadOnlyList<IAxiom> GetAll() => _axioms.AsReadOnly();
+        
+        public void InitializeDefaultAxioms()
+        {
+            Register(new AxiomCollapseThreshold());
+            Register(new AxiomXORFusion());
+            Register(new AxiomSigilDescent());
+            Register(new AxiomQuantumEntanglement());
+        }
+    }
+}

--- a/QuantumCollapseTrader/src/Modules/ReflexGlyphCollapseEngine.cs
+++ b/QuantumCollapseTrader/src/Modules/ReflexGlyphCollapseEngine.cs
@@ -1,0 +1,34 @@
+namespace SymbolicTrading.Axioms
+{
+    // Drives glyph accumulation and applies registered axioms to incoming phases.
+    // Emits axiom events which downstream systems may consume.
+    public class ReflexGlyphCollapseEngine
+    {
+        private readonly Queue<GlyphPhase> _glyphBuffer = new(50);
+        private readonly AxiomRegistry _axiomRegistry;
+        private readonly Queue<AxiomEvent> _axiomQueue = new();
+
+        public ReflexGlyphCollapseEngine(AxiomRegistry registry) =>
+            _axiomRegistry = registry;
+
+        public void ProcessGlyph(GlyphPhase current)
+        {
+            if (_glyphBuffer.Count >= 50) _glyphBuffer.Dequeue();
+            _glyphBuffer.Enqueue(current);
+            
+            foreach (var axiom in _axiomRegistry.GetAll())
+            {
+                if (axiom.Apply(_glyphBuffer.ToList(), current, out var evt))
+                {
+                    _axiomQueue.Enqueue(evt);
+                }
+            }
+        }
+
+        public IEnumerable<AxiomEvent> EmitLatestEvents()
+        {
+            while (_axiomQueue.Count > 0)
+                yield return _axiomQueue.Dequeue();
+        }
+    }
+}

--- a/QuantumCollapseTrader/src/ThinkingEngine.cs
+++ b/QuantumCollapseTrader/src/ThinkingEngine.cs
@@ -1,0 +1,20 @@
+namespace SymbolicTrading.Axioms
+{
+    // Central coordinator that sets up the axiom registry and glyph collapse engine.
+    public class ThinkingEngine
+    {
+        private readonly AxiomRegistry _registry;
+        private readonly ReflexGlyphCollapseEngine _engine;
+
+        public ThinkingEngine()
+        {
+            _registry = new AxiomRegistry();
+            _registry.InitializeDefaultAxioms();
+            _engine = new ReflexGlyphCollapseEngine(_registry);
+        }
+
+        public void Process(GlyphPhase phase) => _engine.ProcessGlyph(phase);
+
+        public IEnumerable<AxiomEvent> EmitEvents() => _engine.EmitLatestEvents();
+    }
+}


### PR DESCRIPTION
## Summary
- add QuantumCollapseTrader project with basic axiom infrastructure
- provide `AxiomRegistry` and `ReflexGlyphCollapseEngine` modules
- add placeholder ThinkingEngine and supporting stub types
- include `.gitignore`

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_6869afc142188320a2a677379d31f3ac