### PR TITLE
Add trading signal classes

### DIFF
--- a/src/Signals/MarkovChainPredictor.cs
+++ b/src/Signals/MarkovChainPredictor.cs
@@ -1,0 +1,38 @@
+namespace SymbolicTrading.Signals
+{
+    // MarkovChainPredictor observes market states and builds a transition matrix for prediction
+    public class MarkovChainPredictor
+    {
+        public enum MarketState
+        {
+            LowVol_UpTrend, LowVol_DownTrend,
+            HighVol_UpTrend, HighVol_DownTrend,
+            Neutral
+        }
+        
+        private MarketState? _lastState;
+        private readonly double[,] _transitionCounts = new double[5,5];
+
+        public void Observe(double entropy, double drift)
+        {
+            var current = Discretize(entropy, drift);
+            if (_lastState.HasValue)
+                _transitionCounts[(int)_lastState, (int)current]++;
+            _lastState = current;
+        }
+
+        private MarketState Discretize(double entropy, double drift)
+        {
+            bool highVol = entropy > 0.7;
+            if (!highVol && drift > 0)
+                return MarketState.LowVol_UpTrend;
+            if (!highVol && drift <= 0)
+                return MarketState.LowVol_DownTrend;
+            if (highVol && drift > 0)
+                return MarketState.HighVol_UpTrend;
+            if (highVol && drift <= 0)
+                return MarketState.HighVol_DownTrend;
+            return MarketState.Neutral;
+        }
+    }
+}

--- a/src/Signals/SymbolMapper.cs
+++ b/src/Signals/SymbolMapper.cs
@@ -1,0 +1,15 @@
+namespace SymbolicTrading.Signals
+{
+    // SymbolMapper converts entropy and drift into symbolic glyphs (☍, ⚯, 🝗, etc.)
+    public class SymbolMapper
+    {
+        public string Map(double entropy, double drift)
+        {
+            if (entropy > 0.8 && drift < -0.2) return "☍";
+            if (entropy > 0.8 && drift > 0.2) return "⚯";
+            if (entropy < 0.3 && drift > 0.3) return "🝗";
+            if (entropy > 0.9 && drift > 0.05) return "⧖";
+            return "◇";
+        }
+    }
+}

--- a/src/ThinkingEngine.cs
+++ b/src/ThinkingEngine.cs
@@ -1,0 +1,14 @@
+namespace SymbolicTrading
+{
+    public class ThinkingEngine
+    {
+        private readonly Signals.SymbolMapper _mapper = new Signals.SymbolMapper();
+        private readonly Signals.MarkovChainPredictor _predictor = new Signals.MarkovChainPredictor();
+
+        public string Process(double entropy, double drift)
+        {
+            _predictor.Observe(entropy, drift);
+            return _mapper.Map(entropy, drift);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add SymbolMapper with symbolic glyph mapping logic
- add MarkovChainPredictor with market state observation
- wire both into new ThinkingEngine
- verify compilation using `mcs`

## Testing
- `mcs -target:library -out:QuantumCollapseTrader.dll src/ThinkingEngine.cs src/Signals/*.cs`

------
https://chatgpt.com/codex/tasks/task_e_6869b219a4e08320b9c0d9e00d43adca