### PR TITLE
Add glyph telemetry and axiom export modules

### DIFF
--- a/src/Export/AxiomLineageCapsule.cs
+++ b/src/Export/AxiomLineageCapsule.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+
+namespace SymbolicTrading.Export
+{
+    // AxiomLineageCapsule defines structured axiom metadata for archival, versioning, and reference
+    public class AxiomLineageCapsule
+    {
+        public string CapsuleID { get; set; } = "AXIOM⇌STABLE⇌025–085";
+        public DateTime Timestamp { get; set; } = DateTime.UtcNow;
+        public List<AxiomEntry> Axioms { get; set; } = new()
+        {
+            new("AXIOM⇌025", "Quantum Collapse", "Failsafe trade closure"),
+            new("AXIOM⇌029", "XOR Fusion Boost", "Amplifies signal strength"),
+            new("AXIOM⇌053", "Sigil Descent", "Reduces trade size"),
+            new("AXIOM⇌061", "Entanglement", "Position sizing boost")
+        };
+    }
+
+    public class AxiomEntry
+    {
+        public string AxiomId { get; }
+        public string Label { get; }
+        public string Description { get; }
+
+        public AxiomEntry(string id, string label, string desc) =>
+            (AxiomId, Label, Description) = (id, label, desc);
+    }
+}

--- a/src/Telemetry/GlyphCapsuleExporter.cs
+++ b/src/Telemetry/GlyphCapsuleExporter.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+
+namespace SymbolicTrading.Telemetry
+{
+    // GlyphCapsuleExporter serializes live glyph streams into timestamped JSON capsules
+    public class GlyphCapsuleExporter
+    {
+        public void Export(string path, IEnumerable<GlyphPhase> glyphs)
+        {
+            var capsule = new
+            {
+                Timestamp = DateTime.UtcNow,
+                Glyphs = glyphs,
+                Signature = "ψ⇌THINKING⇌ENGINE"
+            };
+            
+            File.WriteAllText(path, JsonSerializer.Serialize(capsule, new JsonSerializerOptions
+            {
+                WriteIndented = true
+            }));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `GlyphCapsuleExporter` for emitting glyph capsules
- add `AxiomLineageCapsule` for structured axiom data
- compile new modules with dotnet

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_6869b2d735b0832087e2454da488ee40