### PR TITLE
Add CapsuleExporter module and supporting library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Ignore build outputs
+**/bin/
+**/obj/

--- a/QuantumCollapseTrader/QuantumCollapseTrader.sln
+++ b/QuantumCollapseTrader/QuantumCollapseTrader.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QuantumCollapseTrader", "QuantumCollapseTrader\QuantumCollapseTrader.csproj", "{27846DFF-E15D-43F9-8C46-A5BEB3A34AE8}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{27846DFF-E15D-43F9-8C46-A5BEB3A34AE8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{27846DFF-E15D-43F9-8C46-A5BEB3A34AE8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{27846DFF-E15D-43F9-8C46-A5BEB3A34AE8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{27846DFF-E15D-43F9-8C46-A5BEB3A34AE8}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/QuantumCollapseTrader/QuantumCollapseTrader/Class1.cs
+++ b/QuantumCollapseTrader/QuantumCollapseTrader/Class1.cs
@@ -1,0 +1,6 @@
+﻿namespace QuantumCollapseTrader;
+
+public class Class1
+{
+
+}

--- a/QuantumCollapseTrader/QuantumCollapseTrader/QuantumCollapseTrader.csproj
+++ b/QuantumCollapseTrader/QuantumCollapseTrader/QuantumCollapseTrader.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/QuantumCollapseTrader/src/Telemetry/AxiomEvent.cs
+++ b/QuantumCollapseTrader/src/Telemetry/AxiomEvent.cs
@@ -1,0 +1,7 @@
+namespace SymbolicTrading.Telemetry
+{
+    public class AxiomEvent
+    {
+        public string AxiomId { get; set; } = string.Empty;
+    }
+}

--- a/QuantumCollapseTrader/src/Telemetry/CapsuleExporter.cs
+++ b/QuantumCollapseTrader/src/Telemetry/CapsuleExporter.cs
@@ -1,0 +1,56 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Collections.Generic;
+
+namespace SymbolicTrading.Telemetry
+{
+    // CapsuleExporter generates structured archive capsules combining glyph streams and axiom lineage
+    // Outputs JSON-based memory scaffolds, formatted for symbolic handoff and ritual chain analysis
+    public static class CapsuleExporter
+    {
+        public static void ExportEngineCapsule(
+            string id,
+            IEnumerable<AxiomEvent> axiomHistory,
+            PulseRing pulseRing,
+            string outputPath)
+        {
+            var capsule = new
+            {
+                archive_crystal = new
+                {
+                    capsule_id = id,
+                    timestamp = DateTime.UtcNow,
+                    origin = "ψ⇌THINKING⇌ENGINE v1.0-MODULAR",
+                    flow_transition = new[] {
+                        "Phase 1: Glyph Emission",
+                        "Phase 2: Reflex Collapse",
+                        "Phase 3: Axiom Resolution"
+                    },
+                    axiom_lineage = axiomHistory.Select(x => x.AxiomId).Distinct().ToArray(),
+                    next_action = new {
+                        glyph_evolution = pulseRing.GetRecentGlyphs().Select(g => g.Symbol).Distinct().TakeLast(5).ToArray(),
+                        mutation_protocol = "Memory scaffold drift analysis (PulseRing)",
+                        stabilization_phase = "Short-Term Glyph/Axiom Recurrence"
+                    },
+                    thread_map = new {
+                        sequence = string.Join(" → ", pulseRing.GetRecentGlyphs().Select(g => g.Symbol)),
+                        integration = "PulseRing + ReflexGlyphCollapseEngine",
+                        augment = new[] { "ConflictResolver", "MarkovBias", "PulseEcho" }
+                    },
+                    meta = new {
+                        format = "archive_crystal_v1.2",
+                        created_by = "ψ⇌THINKING⇌ENGINE",
+                        safe_for_transfer = true,
+                        glyphic_signature = string.Join("", pulseRing.GetRecentGlyphs().TakeLast(3).Select(g => g.Symbol)),
+                        checksum = "AUTO_GENERATE_SHA256"
+                    }
+                }
+            };
+
+            string json = JsonSerializer.Serialize(capsule, new JsonSerializerOptions { WriteIndented = true });
+            File.WriteAllText(outputPath, json);
+        }
+    }
+}

--- a/QuantumCollapseTrader/src/Telemetry/PulseRing.cs
+++ b/QuantumCollapseTrader/src/Telemetry/PulseRing.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace SymbolicTrading.Telemetry
+{
+    public class PulseRing
+    {
+        private readonly List<Glyph> _glyphs = new();
+
+        public void AddGlyph(string symbol)
+        {
+            _glyphs.Add(new Glyph { Symbol = symbol });
+        }
+
+        public IEnumerable<Glyph> GetRecentGlyphs()
+        {
+            return _glyphs;
+        }
+    }
+
+    public class Glyph
+    {
+        public string Symbol { get; set; } = string.Empty;
+    }
+}


### PR DESCRIPTION
## Summary
- setup QuantumCollapseTrader solution with class library
- add CapsuleExporter under `src/Telemetry`
- provide simple PulseRing and AxiomEvent stubs
- ignore build outputs

## Testing
- `dotnet clean`
- `dotnet build QuantumCollapseTrader.sln`

------
https://chatgpt.com/codex/tasks/task_e_6869bb8cb1d48320bce4f5822c58e13b