### PR TITLE
Add SymbolicOutcomeMatrix tests and implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+bin/
+obj/
+**/bin/
+**/obj/

--- a/QuantumCollapseTrader.sln
+++ b/QuantumCollapseTrader.sln
@@ -1,0 +1,36 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{B97966F1-BFDC-42C2-9F53-E5EDEB835DAC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SymbolicTrading.Memory", "src\SymbolicTrading.Memory\SymbolicTrading.Memory.csproj", "{9709B255-A913-4C32-9FF2-426024797536}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{EA1AB749-77E5-4FC4-AD32-BE42A39488BC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnitTests", "tests\UnitTests\UnitTests.csproj", "{FF49019B-1575-4BAE-BB78-36A2B4D6636B}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{9709B255-A913-4C32-9FF2-426024797536}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9709B255-A913-4C32-9FF2-426024797536}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9709B255-A913-4C32-9FF2-426024797536}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9709B255-A913-4C32-9FF2-426024797536}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FF49019B-1575-4BAE-BB78-36A2B4D6636B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FF49019B-1575-4BAE-BB78-36A2B4D6636B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FF49019B-1575-4BAE-BB78-36A2B4D6636B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FF49019B-1575-4BAE-BB78-36A2B4D6636B}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{9709B255-A913-4C32-9FF2-426024797536} = {B97966F1-BFDC-42C2-9F53-E5EDEB835DAC}
+		{FF49019B-1575-4BAE-BB78-36A2B4D6636B} = {EA1AB749-77E5-4FC4-AD32-BE42A39488BC}
+	EndGlobalSection
+EndGlobal

--- a/src/SymbolicTrading.Memory/GlyphRecord.cs
+++ b/src/SymbolicTrading.Memory/GlyphRecord.cs
@@ -1,0 +1,8 @@
+namespace SymbolicTrading.Memory
+{
+    public class GlyphRecord
+    {
+        public string Symbol { get; set; } = string.Empty;
+        public double Pnl { get; set; }
+    }
+}

--- a/src/SymbolicTrading.Memory/MatrixEntry.cs
+++ b/src/SymbolicTrading.Memory/MatrixEntry.cs
@@ -1,0 +1,8 @@
+namespace SymbolicTrading.Memory
+{
+    public class MatrixEntry
+    {
+        public string motif { get; set; } = string.Empty;
+        public decimal avgPnl { get; set; }
+    }
+}

--- a/src/SymbolicTrading.Memory/SymbolicOutcomeMatrix.cs
+++ b/src/SymbolicTrading.Memory/SymbolicOutcomeMatrix.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace SymbolicTrading.Memory
+{
+    public class SymbolicOutcomeMatrix
+    {
+        private readonly int _memory;
+        private readonly Dictionary<string, (decimal sum, int count)> _data = new();
+
+        public SymbolicOutcomeMatrix(int memory)
+        {
+            _memory = memory;
+        }
+
+        public void Observe(IReadOnlyList<GlyphRecord> records)
+        {
+            if (records.Count < _memory)
+                return;
+
+            for (int i = 0; i <= records.Count - _memory; i++)
+            {
+                var slice = records.Skip(i).Take(_memory).ToList();
+                var motif = string.Join("\u2192", slice.Select(r => r.Symbol));
+                var pnlSum = slice.Sum(r => (decimal)r.Pnl);
+
+                if (_data.TryGetValue(motif, out var entry))
+                {
+                    _data[motif] = (entry.sum + pnlSum, entry.count + 1);
+                }
+                else
+                {
+                    _data[motif] = (pnlSum, 1);
+                }
+            }
+        }
+
+        public List<MatrixEntry> ExportMatrix()
+        {
+            var result = new List<MatrixEntry>();
+            foreach (var kvp in _data)
+            {
+                var avg = kvp.Value.count > 0 ? kvp.Value.sum / kvp.Value.count : 0m;
+                result.Add(new MatrixEntry { motif = kvp.Key, avgPnl = avg });
+            }
+            return result;
+        }
+    }
+}

--- a/src/SymbolicTrading.Memory/SymbolicTrading.Memory.csproj
+++ b/src/SymbolicTrading.Memory/SymbolicTrading.Memory.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/tests/UnitTests/GlobalUsings.cs
+++ b/tests/UnitTests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/tests/UnitTests/OutcomeMatrixTests.cs
+++ b/tests/UnitTests/OutcomeMatrixTests.cs
@@ -1,0 +1,50 @@
+using Xunit;
+using SymbolicTrading.Memory;
+using System.Collections.Generic;
+
+namespace SymbolicTrading.Tests
+{
+    /// <summary>
+    /// SymbolicOutcomeMatrixTests ensures motif detection and aggregation behaves correctly
+    /// Validates motif string formatting, PnL summation, and statistical memory output
+    /// </summary>
+    public class SymbolicOutcomeMatrixTests
+    {
+        [Fact]
+        public void Observe_ShouldBuildMotifMatrix()
+        {
+            var matrix = new SymbolicOutcomeMatrix(3);
+            var records = new List<GlyphRecord> {
+                new() { Symbol = "☍", Pnl = 1.0 },
+                new() { Symbol = "🝗", Pnl = 2.0 },
+                new() { Symbol = "⚯", Pnl = 3.0 }
+            };
+
+            matrix.Observe(records);
+            var grid = matrix.ExportMatrix();
+
+            Assert.Single(grid);
+            Assert.Equal("☍→🝗→⚯", grid[0].motif);
+            Assert.Equal(6.0, (double)grid[0].avgPnl, 3);
+        }
+
+        [Fact]
+        public void MultipleObservations_ShouldAggregate()
+        {
+            var matrix = new SymbolicOutcomeMatrix(2);
+            var records = new List<GlyphRecord> {
+                new() { Symbol = "☍", Pnl = 1.0 },
+                new() { Symbol = "🝗", Pnl = 2.0 },
+                new() { Symbol = "☍", Pnl = -1.0 },
+                new() { Symbol = "🝗", Pnl = -2.0 }
+            };
+
+            matrix.Observe(records);
+            var grid = matrix.ExportMatrix();
+
+            Assert.Equal(2, grid.Count);
+            Assert.Equal("☍→🝗", grid[0].motif);
+            Assert.Equal(0.0, (double)grid[0].avgPnl, 3);
+        }
+    }
+}

--- a/tests/UnitTests/UnitTests.csproj
+++ b/tests/UnitTests/UnitTests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\SymbolicTrading.Memory\SymbolicTrading.Memory.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- add xUnit test project and add SymbolicOutcomeMatrixTests with integration comments
- implement minimal SymbolicTrading.Memory library supporting tests
- create solution file and ignore build artifacts

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6869bd69b228832094205ad1598b644f