### PR TITLE
Add SymbolicTrading intelligence modules

### DIFF
--- a/QuantumCollapseTrader/src/Intelligence/AxiomEvolver.cs
+++ b/QuantumCollapseTrader/src/Intelligence/AxiomEvolver.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using SymbolicTrading.Axioms;
+using SymbolicTrading.Telemetry;
+
+namespace SymbolicTrading.Intelligence
+{
+    // Integration: coordinates with QuantumCollapseTrader.cs to adapt axioms
+    // Based on trade outcomes recorded in OutcomeMatrix and fractal feedback
+    // from PulseRing, this module mutates entries in AxiomRegistry.
+    public class AxiomEvolver
+    {
+        private readonly AxiomRegistry _registry;
+        private readonly Dictionary<string, AxiomPerformance> _performanceMetrics = new();
+        private readonly IEchoFractalTracker _fractalTracker;
+
+        public AxiomEvolver(AxiomRegistry registry, IEchoFractalTracker fractalTracker)
+        {
+            _registry = registry;
+            _fractalTracker = fractalTracker;
+        }
+
+        public void RecordOutcome(string axiomId, double pnlImpact, bool wasTriggered)
+        {
+            if (!_performanceMetrics.ContainsKey(axiomId))
+            {
+                _performanceMetrics[axiomId] = new AxiomPerformance();
+            }
+
+            var metric = _performanceMetrics[axiomId];
+            metric.TotalTriggers++;
+            metric.CumulativePnl += pnlImpact;
+            if (wasTriggered) metric.ActivationCount++;
+        }
+
+        public void EvolveLogic(double evolutionThreshold = 0.65)
+        {
+            foreach (var (axiomId, metric) in _performanceMetrics.ToList())
+            {
+                double successRate = metric.SuccessRate;
+                double activationRate = metric.ActivationRate;
+                if (successRate < evolutionThreshold)
+                {
+                    MutateAxiom(axiomId, successRate, activationRate);
+                }
+            }
+        }
+
+        private void MutateAxiom(string axiomId, double successRate, double activationRate)
+        {
+            var axiom = _registry.GetAxiom(axiomId);
+            if (axiom == null) return;
+
+            // Evolutionary mutation logic updates the axiom configuration
+            string mutationType = successRate < 0.4 ? "REPLACE" : "ADJUST";
+            var context = _fractalTracker.GetRecentContext();
+
+            axiom.AdjustWeights(
+                activationBoost: activationRate < 0.3 ? 1.5 : 0.8,
+                strictnessFactor: successRate < 0.5 ? 0.7 : 1.2
+            );
+
+            // Mutation events are tracked so QuantumCollapseTrader.cs can
+            // correlate fractal state with axiom performance.
+            _fractalTracker.RecordMutation(axiomId, mutationType, context);
+        }
+
+        private class AxiomPerformance
+        {
+            public int TotalTriggers { get; set; }
+            public int ActivationCount { get; set; }
+            public double CumulativePnl { get; set; }
+            public double SuccessRate => TotalTriggers > 0 ? CumulativePnl / TotalTriggers : 0;
+            public double ActivationRate => TotalTriggers > 0 ? (double)ActivationCount / TotalTriggers : 0;
+        }
+    }
+
+    // Interface is implemented by any Axiom that can adjust its weights at runtime
+    public interface IAxiomAdjustable
+    {
+        void AdjustWeights(double activationBoost, double strictnessFactor);
+    }
+}

--- a/QuantumCollapseTrader/src/Patterns/GlyphMotifReactor.cs
+++ b/QuantumCollapseTrader/src/Patterns/GlyphMotifReactor.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using SymbolicTrading.Memory;
+
+namespace SymbolicTrading.Patterns
+{
+    // Integration: leverages OutcomeMatrix statistics and recent PulseRing glyphs
+    // to shape trade bias used by QuantumCollapseTrader.cs. Motifs that yield
+    // strong performance get stored as boosts while weak motifs signal avoidance.
+    public class GlyphMotifReactor
+    {
+        private readonly SymbolicOutcomeMatrix _outcomeMatrix;
+        private readonly PulseRing _pulseRing;
+        private readonly Dictionary<string, double> _motifBoosts = new();
+
+        public GlyphMotifReactor(SymbolicOutcomeMatrix outcomeMatrix, PulseRing pulseRing)
+        {
+            _outcomeMatrix = outcomeMatrix;
+            _pulseRing = pulseRing;
+        }
+
+        public void RefreshMotifBoosts(double successThreshold = 0.75)
+        {
+            var matrix = _outcomeMatrix.ExportMatrix();
+            foreach (var entry in matrix)
+            {
+                if (entry.successRate >= successThreshold && entry.count > 5)
+                {
+                    // Calculate boost based on performance
+                    double boost = 1.0 + (0.1 * entry.avgPnl);
+                    _motifBoosts[entry.motif] = Math.Min(boost, 2.0);
+                }
+            }
+        }
+
+        public double GetPositionBoost()
+        {
+            var recentGlyphs = _pulseRing.GetRecentGlyphs(3);
+            if (recentGlyphs.Count < 3) return 1.0;
+
+            string motif = string.Join("→", recentGlyphs.Select(g => g.Symbol));
+            return _motifBoosts.TryGetValue(motif, out var boost) ? boost : 1.0;
+        }
+
+        public bool ShouldAvoidTrade(string currentSymbol)
+        {
+            var recent = _pulseRing.GetRecentGlyphs(2).Select(g => g.Symbol).ToList();
+            if (recent.Count < 2) return false;
+
+            // Avoid repeating losing patterns that are reflected in OutcomeMatrix
+            string sequence = $"{recent[0]}→{recent[1]}→{currentSymbol}";
+            return _motifBoosts.TryGetValue(sequence, out var boost) && boost < 0.9;
+        }
+    }
+}

--- a/QuantumCollapseTrader/src/Signals/SymbolEntropyProfiler.cs
+++ b/QuantumCollapseTrader/src/Signals/SymbolEntropyProfiler.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace SymbolicTrading.Signals
+{
+    // Integration: records market entropy and links readings with price drift.
+    // QuantumCollapseTrader.cs queries this profiler alongside PulseRing data to
+    // understand emotional market swings.
+    public class SymbolEntropyProfiler
+    {
+        private readonly Dictionary<string, EntropyProfile> _profiles = new();
+        private readonly int _profileSize;
+
+        public SymbolEntropyProfiler(int profileSize = 100)
+        {
+            _profileSize = profileSize;
+        }
+
+        public void RecordEntropy(string symbol, double entropy, double priceDrift)
+        {
+            if (!_profiles.TryGetValue(symbol, out var profile))
+            {
+                profile = new EntropyProfile(_profileSize);
+                _profiles[symbol] = profile;
+            }
+            profile.AddReading(entropy, priceDrift);
+        }
+
+        public EntropyMetrics GetMetrics(string symbol)
+        {
+            if (_profiles.TryGetValue(symbol, out var profile))
+            {
+                return profile.CalculateMetrics();
+            }
+            return new EntropyMetrics();
+        }
+
+        public double GetEmotionalDrift(string symbol)
+        {
+            var metrics = GetMetrics(symbol);
+            return metrics.EntropyVolatility * metrics.DriftCorrelation;
+        }
+
+        public class EntropyProfile
+        {
+            private readonly int _capacity;
+            private readonly Queue<double> _entropyReadings = new();
+            private readonly Queue<double> _driftReadings = new();
+
+            public EntropyProfile(int capacity) => _capacity = capacity;
+
+            public void AddReading(double entropy, double drift)
+            {
+                _entropyReadings.Enqueue(entropy);
+                _driftReadings.Enqueue(drift);
+                if (_entropyReadings.Count > _capacity)
+                {
+                    _entropyReadings.Dequeue();
+                    _driftReadings.Dequeue();
+                }
+            }
+
+            public EntropyMetrics CalculateMetrics()
+            {
+                if (_entropyReadings.Count < 5) return new EntropyMetrics();
+
+                return new EntropyMetrics
+                {
+                    AverageEntropy = _entropyReadings.Average(),
+                    EntropyVolatility = CalculateVolatility(_entropyReadings),
+                    DriftCorrelation = CalculateCorrelation(),
+                    DecayRate = CalculateDecayRate()
+                };
+            }
+
+            private double CalculateVolatility(IEnumerable<double> values)
+            {
+                var avg = values.Average();
+                var sumSquares = values.Sum(v => Math.Pow(v - avg, 2));
+                return Math.Sqrt(sumSquares / values.Count());
+            }
+
+            private double CalculateCorrelation()
+            {
+                // Simple correlation between entropy and price drift
+                var entropyArray = _entropyReadings.ToArray();
+                var driftArray = _driftReadings.ToArray();
+                double sumProd = 0;
+                for (int i = 0; i < entropyArray.Length; i++)
+                {
+                    sumProd += entropyArray[i] * driftArray[i];
+                }
+                return sumProd / (entropyArray.Length * entropyArray.Average() * driftArray.Average());
+            }
+
+            private double CalculateDecayRate()
+            {
+                // Calculate entropy decay rate over last 10% of readings
+                int count = _entropyReadings.Count;
+                int sampleSize = Math.Max(5, count / 10);
+                var recent = _entropyReadings.TakeLast(sampleSize).ToArray();
+                return (recent.Last() - recent.First()) / sampleSize;
+            }
+        }
+
+        public struct EntropyMetrics
+        {
+            public double AverageEntropy { get; set; }
+            public double EntropyVolatility { get; set; }
+            public double DriftCorrelation { get; set; }
+            public double DecayRate { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- scaffold `AxiomEvolver` in `SymbolicTrading.Intelligence`
- scaffold `GlyphMotifReactor` in `SymbolicTrading.Patterns`
- scaffold `SymbolEntropyProfiler` in `SymbolicTrading.Signals`

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869c732a5bc83208065d599dac31508