### PR TITLE
Add risk management, session weighting, and metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![CI](https://github.com/OWNER/REPO/actions/workflows/ci.yml/badge.svg?branch=main)
 
-Turn **entropy drift** (ΔΦ) into **adaptive trades**.  
+Turn **entropy drift** (ΔΦ) into **adaptive trades**.
 Verdicts: ⟿ collapse (trend conviction), ⚖ sat-like (flat), ☑ recovered (no trade).
 
 ## Quick start
@@ -16,6 +16,11 @@ Artifacts land in artifacts/ as:
 
 
 > Replace `OWNER/REPO` in the badge URL with your GitHub path after pushing.
+
+### Risk & Sessions
+- Sizing = %equity / (ATR * multiplier). Default: risk 1.6%, stop = 1.5×ATR, RR=2.5.
+- Session multiplier: Asia 0.6×, London 1.0×, NY 1.5× (affects position size).
+- Metrics auto-emitted to `artifacts/metrics.json` after `--report`.
 
 ### `src/entropy_engine.py`
 ```python
@@ -62,7 +67,8 @@ def verdict_from_series(dphi: np.ndarray) -> Verdict:
         recovered = tail.size > 0 and np.all(tail <= RECOV_EPS)
 
     no_recovery = not recovered
-    sat_like = bool(np.all(np.diff(dphi) <= 1e-12))
+    # tolerate tiny floating point drift when checking for non-increasing series
+    sat_like = bool(np.all(np.diff(dphi) <= 1e-9))
 
     glyph = "⟿" if (np_wall and no_recovery and not sat_like) else ("⚖" if sat_like else "☑")
     return Verdict(np_wall, no_recovery, sat_like, glyph, float(dphi[-1]))

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+# makes src a package for -m entry points and tests

--- a/src/backtest_runner.py
+++ b/src/backtest_runner.py
@@ -1,6 +1,7 @@
 import argparse, json, os
 import pandas as pd
 from .strategy import EntropyStrategy, Params
+from .metrics import load_trades, compute_metrics
 
 def load_csv(path: str) -> pd.DataFrame:
     df = pd.read_csv(path)
@@ -26,6 +27,9 @@ def main():
         os.makedirs("artifacts", exist_ok=True)
         with open("artifacts/report.json", "w") as f:
             json.dump(res, f, indent=2)
+        mets = compute_metrics(load_trades("artifacts/trades.ndjson"))
+        with open("artifacts/metrics.json", "w") as f:
+            json.dump(mets, f, indent=2)
 
 if __name__ == "__main__":
     main()

--- a/src/entropy_engine.py
+++ b/src/entropy_engine.py
@@ -42,7 +42,8 @@ def verdict_from_series(dphi: np.ndarray) -> Verdict:
         recovered = tail.size > 0 and np.all(tail <= RECOV_EPS)
 
     no_recovery = not recovered
-    sat_like = bool(np.all(np.diff(dphi) <= 1e-12))
+    # tolerate tiny floating point drift when checking for non-increasing series
+    sat_like = bool(np.all(np.diff(dphi) <= 1e-9))
 
     glyph = "⟿" if (np_wall and no_recovery and not sat_like) else ("⚖" if sat_like else "☑")
     return Verdict(np_wall, no_recovery, sat_like, glyph, float(dphi[-1]))

--- a/src/metrics.py
+++ b/src/metrics.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+import json, os
+from typing import List, Dict
+
+
+def load_trades(ndjson_path: str) -> List[Dict]:
+    if not os.path.exists(ndjson_path): return []
+    out = []
+    with open(ndjson_path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                out.append(json.loads(line))
+    return out
+
+
+def compute_metrics(trades: List[Dict]) -> Dict:
+    pnl = [t.get("pnl", 0.0) for t in trades]
+    wins = sum(1 for x in pnl if x > 0)
+    losses = sum(1 for x in pnl if x <= 0)
+    eq = 0.0; peak = 0.0; maxdd = 0.0
+    for x in pnl:
+        eq += x
+        peak = max(peak, eq)
+        maxdd = min(maxdd, eq - peak)
+    return {
+        "trades": len(pnl),
+        "wins": wins, "losses": losses,
+        "win_rate": (wins / len(pnl)) if pnl else 0.0,
+        "net_pnl": sum(pnl),
+        "max_drawdown": maxdd
+    }
+

--- a/src/risk.py
+++ b/src/risk.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+from dataclasses import dataclass
+import math
+
+
+@dataclass
+class RiskParams:
+    risk_pct: float = 0.016   # 1.6% of equity
+    rr: float = 2.5           # reward:risk
+    atr_mult: float = 1.5     # stop = ATR * atr_mult
+    min_size: int = 1
+
+
+def position_size(equity: float, atr_value: float, price: float, p: RiskParams) -> int:
+    # Instrument-agnostic demo: $1 move = 1 PnL unit
+    stop_dist = max(1e-6, atr_value * p.atr_mult)
+    cash_risk = max(0.0, equity * p.risk_pct)
+    size = math.floor(cash_risk / stop_dist)
+    return max(p.min_size, size)
+
+
+def stops_targets(entry: float, side: str, atr_value: float, p: RiskParams) -> tuple[float, float]:
+    sdist = max(1e-6, atr_value * p.atr_mult)
+    if side == "long":
+        return entry - sdist, entry + sdist * p.rr
+    elif side == "short":
+        return entry + sdist, entry - sdist * p.rr
+    return entry, entry
+

--- a/src/session.py
+++ b/src/session.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+from dataclasses import dataclass
+import pandas as pd
+
+
+@dataclass
+class SessionWeights:
+    asia: float = 0.6
+    london: float = 1.0
+    ny: float = 1.5
+
+
+def session_weight(ts: pd.Timestamp, w: SessionWeights = SessionWeights()) -> float:
+    # Simple UTC bands (tweak to your feed TZ):
+    h = ts.hour
+    if 0 <= h < 8:     # Asia
+        return w.asia
+    if 8 <= h < 13:    # London
+        return w.london
+    return w.ny       # NY default
+

--- a/src/strategy.py
+++ b/src/strategy.py
@@ -3,18 +3,22 @@ import pandas as pd
 from dataclasses import dataclass
 from .entropy_engine import atr, delta_phi, verdict_from_series
 from .capsule_logger import trade_capsule, write_ndjson
+from .risk import RiskParams, position_size, stops_targets
+from .session import session_weight
+
 
 @dataclass
 class Params:
-    risk_pct: float = 0.016
-    rr: float = 2.5
+    risk: RiskParams = RiskParams()
     atr_period: int = 14
 
+
 class EntropyStrategy:
-    def __init__(self, symbol: str, params: Params, outdir: str = "artifacts"):
+    def __init__(self, symbol: str, params: Params, outdir: str = "artifacts", equity: float = 50000.0):
         self.symbol = symbol
         self.p = params
         self.outdir = outdir
+        self.equity = equity
 
     def run(self, df: pd.DataFrame, hud: bool = False) -> dict:
         high, low, close = df["high"].values, df["low"].values, df["close"].values
@@ -22,27 +26,33 @@ class EntropyStrategy:
         dphi = delta_phi(atr_vals, close)
         verdict = verdict_from_series(dphi)
 
-        # naive toy rule: go with collapse (⟿) in last 20 bars trend direction
         side = "wait"
-        if verdict.glyph == "⟿":
+        if verdict.glyph == "⟿":  # collapse → trend-follow
             side = "long" if close[-1] > close[-20] else "short"
 
-        # one-bar “trade” for demo
-        entry, exit_ = float(close[-2]), float(close[-1])
+        entry = float(close[-1])
         if side != "wait":
-            cap = trade_capsule(self.symbol, side, entry, exit_,
-                                {"np_wall": verdict.np_wall, "no_recovery": verdict.no_recovery,
-                                 "sat_like": verdict.sat_like, "glyph": verdict.glyph,
-                                 "ΔΦ_last": verdict.delta_phi},
-                                str(df.index[-2]), str(df.index[-1]))
+            # session weighting on size
+            ts = df.index[-1] if isinstance(df.index, pd.DatetimeIndex) else None
+            w = session_weight(ts) if ts is not None else 1.0
+            size = max(1, int(position_size(self.equity, float(atr_vals[-1]), entry, self.p.risk) * w))
+
+            stop, target = stops_targets(entry, side, float(atr_vals[-1]), self.p.risk)
+
+            # demo exit: mark-to-market at last close (replace with bar-by-bar in Phase 4)
+            exit_px = float(close[-1])
+            cap = trade_capsule(
+                self.symbol, side, entry, exit_px,
+                {
+                    "np_wall": verdict.np_wall, "no_recovery": verdict.no_recovery,
+                    "sat_like": verdict.sat_like, "glyph": verdict.glyph, "ΔΦ_last": verdict.delta_phi,
+                    "size": size, "stop": stop, "target": target
+                },
+                str(df.index[-1]), str(df.index[-1])
+            )
             write_ndjson(f"{self.outdir}/trades.ndjson", cap)
 
         if hud:
-            print(f"{self.symbol} ΔΦ_last={verdict.delta_phi:.3f} verdict={verdict.glyph} side={side}")
+            print(f"{self.symbol} ΔΦ={verdict.delta_phi:.3f} glyph={verdict.glyph} side={side}")
+        return {"symbol": self.symbol, "glyph": verdict.glyph, "side": side, "delta_phi_last": verdict.delta_phi}
 
-        return {
-            "symbol": self.symbol,
-            "glyph": verdict.glyph,
-            "side": side,
-            "delta_phi_last": verdict.delta_phi
-        }

--- a/tests/test_verdict_edges.py
+++ b/tests/test_verdict_edges.py
@@ -1,0 +1,16 @@
+import numpy as np
+from src.entropy_engine import verdict_from_series, NP_WALL, RECOV_EPS
+
+
+def test_last_spike_logic():
+    d = np.array([0.01, 0.12, 0.03, 0.10, 0.08, 0.07])  # last spike at idx=3
+    v = verdict_from_series(d)
+    assert v.np_wall and v.glyph in {"⟿", "☑", "⚖"}  # just assert spike detection didn't crash
+
+
+def test_recovery_detects_tail_below_eps():
+    d = np.array([0.01, NP_WALL + 0.02, RECOV_EPS * 0.9, RECOV_EPS * 0.8, RECOV_EPS * 0.7, 0.02])
+    v = verdict_from_series(d)
+    # spike then full tail below epsilon → recovered → no_recovery False
+    assert v.np_wall and (v.glyph in {"☑", "⚖"})
+


### PR DESCRIPTION
## Summary
- implement risk position sizing and stop/target helpers
- add session-based size weighting and trade metrics
- allow small FP drift in entropy verdict non-increasing check

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c337c5c08c8320b4e61e4cdbf961d1