### PR TITLE
Add daily trading policy and multi-entry backtest

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,19 @@ def verdict_from_series(dphi: np.ndarray) -> Verdict:
     glyph = "⟿" if (np_wall and no_recovery and not sat_like) else ("⚖" if sat_like else "☑")
     return Verdict(np_wall, no_recovery, sat_like, glyph, float(dphi[-1]))
 ```
+
+### Multi-entry backtest (with daily clamp & cooldown)
+```bash
+python -m src.multi_backtest \
+  --csv data/sample_ohlcv.csv \
+  --symbol ES \
+  --max-trades 8 \
+  --dd-r -5 \
+  --cooldown 10 \
+  --lookahead 64
+```
+
+Artifacts:
+    • artifacts/trades.ndjson – one capsule per trade
+    • artifacts/session_summary.json – total trades + cumulative R
+

--- a/src/multi_backtest.py
+++ b/src/multi_backtest.py
@@ -1,0 +1,44 @@
+import argparse, json, os
+import pandas as pd
+from .risk import RiskParams
+from .policy import DayPolicy
+from .scanner import multi_entry_scan
+
+def load_csv(path: str) -> pd.DataFrame:
+    df = pd.read_csv(path)
+    if "timestamp" in df.columns:
+        df["timestamp"] = pd.to_datetime(df["timestamp"])
+        df = df.set_index("timestamp")
+    return df
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--csv", required=True)
+    ap.add_argument("--symbol", default="ES")
+    ap.add_argument("--atr", type=int, default=14)
+    ap.add_argument("--lookahead", type=int, default=64)
+    ap.add_argument("--cooldown", type=int, default=10)
+    ap.add_argument("--max-trades", type=int, default=8)
+    ap.add_argument("--dd-r", type=float, default=-5.0)
+    ap.add_argument("--risk-pct", type=float, default=0.016)
+    ap.add_argument("--rr", type=float, default=2.5)
+    ap.add_argument("--atr-mult", type=float, default=1.5)
+    args = ap.parse_args()
+
+    df = load_csv(args.csv)
+    trades, cumR = multi_entry_scan(
+        df=df,
+        symbol=args.symbol,
+        risk=RiskParams(risk_pct=args.risk_pct, rr=args.rr, atr_mult=args.atr_mult),
+        atr_period=args.atr,
+        look_ahead_bars=args.lookahead,
+        cooldown_bars=args.cooldown,
+        day_policy=DayPolicy(max_trades=args.max_trades, dd_limit_r=args.dd_r),
+    )
+    os.makedirs("artifacts", exist_ok=True)
+    with open("artifacts/session_summary.json", "w") as f:
+        json.dump({"symbol": args.symbol, "trades": trades, "cumR": cumR}, f, indent=2)
+    print(f"[OK] {args.symbol} trades={trades} cumR={cumR:.2f}")
+
+if __name__ == "__main__":
+    main()

--- a/src/policy.py
+++ b/src/policy.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import Dict
+
+@dataclass
+class DayPolicy:
+    max_trades: int = 8          # per calendar day
+    dd_limit_r: float = -5.0     # stop trading day if cumR <= this
+    _count: int = 0
+    _cum_r: float = 0.0
+
+    def can_enter(self) -> bool:
+        return self._count < self.max_trades and self._cum_r > self.dd_limit_r
+
+    def register(self, r_mult: float) -> None:
+        self._count += 1
+        self._cum_r += r_mult
+
+@dataclass
+class DailyBook:
+    policy_template: DayPolicy = field(default_factory=DayPolicy)
+    days: Dict[str, DayPolicy] = field(default_factory=dict)
+
+    def policy_for(self, day_key: str) -> DayPolicy:
+        if day_key not in self.days:
+            self.days[day_key] = DayPolicy(
+                max_trades=self.policy_template.max_trades,
+                dd_limit_r=self.policy_template.dd_limit_r
+            )
+        return self.days[day_key]

--- a/src/scanner.py
+++ b/src/scanner.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+import pandas as pd
+import numpy as np
+from typing import Iterable, Tuple
+from .entropy_engine import atr, delta_phi, verdict_from_series
+from .risk import RiskParams, position_size, stops_targets
+from .session import session_weight
+from .execution import fill_trade
+from .capsule_logger import trade_capsule, write_ndjson
+from .policy import DailyBook, DayPolicy
+
+
+def collapse_direction(close: np.ndarray, lookback: int = 20) -> str:
+    if close.size <= lookback: return "wait"
+    return "long" if close[-1] > close[-lookback] else "short"
+
+def stream_dphi(high: np.ndarray, low: np.ndarray, close: np.ndarray, atr_period: int) -> np.ndarray:
+    a = atr(high, low, close, atr_period)
+    return delta_phi(a, close)
+
+def multi_entry_scan(
+    df: pd.DataFrame,
+    symbol: str,
+    risk: RiskParams,
+    outdir: str = "artifacts",
+    atr_period: int = 14,
+    look_ahead_bars: int = 64,
+    cooldown_bars: int = 10,
+    day_policy: DayPolicy = DayPolicy(),
+    equity: float = 50_000.0,
+) -> Tuple[int, float]:
+    """
+    Walks the chart; on each bar i, compute verdict from a rolling window (up to i),
+    fire on collapse (⟿), then simulate bar-by-bar fills forward.
+    Returns (num_trades, cumR).
+    """
+    assert isinstance(df.index, pd.DatetimeIndex), "df index must be DatetimeIndex"
+    high, low, close = df["high"].values, df["low"].values, df["close"].values
+    dphi_all = stream_dphi(high, low, close, atr_period)
+    book = DailyBook(day_policy)
+
+    trades = 0
+    cumR = 0.0
+    cooldown = 0
+
+    warmup = max(atr_period + 20, 30)
+    for i in range(warmup, len(close) - 2):
+        ts = df.index[i]
+        day_key = ts.date().isoformat()
+        policy = book.policy_for(day_key)
+
+        if cooldown > 0:
+            cooldown -= 1
+            continue
+        if not policy.can_enter():
+            continue
+
+        # verdict from series up to i (rolling)
+        v = verdict_from_series(dphi_all[: i + 1])
+        if v.glyph != "⟿":
+            continue
+
+        side = collapse_direction(close[: i + 1])
+        if side == "wait":
+            continue
+
+        entry = float(close[i])
+        w = session_weight(ts)
+        atr_i = float(atr(high, low, close, atr_period)[i])  # reuse function for clarity
+        size = max(1, int(position_size(equity, atr_i, entry, risk) * w))
+        stop, target = stops_targets(entry, side, atr_i, risk)
+
+        highs_next = high[i + 1 : i + 1 + look_ahead_bars]
+        lows_next  = low [i + 1 : i + 1 + look_ahead_bars]
+        exit_px, reason, bars_held = fill_trade(entry, side, stop, target, highs_next, lows_next)
+
+        risk_per_unit = abs(entry - stop)
+        r_mult = ((exit_px - entry) if side == "long" else (entry - exit_px)) / risk_per_unit if risk_per_unit > 0 else 0.0
+        cumR += r_mult
+        trades += 1
+        policy.register(r_mult)
+        cooldown = cooldown_bars
+
+        cap = trade_capsule(
+            symbol, side, entry, exit_px,
+            {
+                "glyph": v.glyph, "np_wall": v.np_wall, "no_recovery": v.no_recovery,
+                "sat_like": v.sat_like, "ΔΦ_last": v.delta_phi, "size": size,
+                "stop": stop, "target": target, "exit_reason": reason, "bars_held": bars_held, "R": r_mult
+            },
+            str(ts), str(df.index[min(len(df.index) - 1, i + 1 + bars_held)])
+        )
+        write_ndjson(f"{outdir}/trades.ndjson", cap)
+
+    return trades, cumR

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -1,0 +1,7 @@
+from src.policy import DayPolicy
+
+def test_day_policy_clamp():
+    p = DayPolicy(max_trades=2, dd_limit_r=-1.0)
+    assert p.can_enter()
+    p.register(-0.6); assert p.can_enter()
+    p.register(-0.5); assert not p.can_enter()  # cumR = -1.1 ≤ limit


### PR DESCRIPTION
## Summary
- Add `DayPolicy` and `DailyBook` to limit daily trades and enforce drawdown stop
- Implement `multi_entry_scan` with cooldown and daily policy tracking
- Provide `multi_backtest` CLI for running multi-entry backtests
- Add test ensuring daily policy clamps trading when drawdown limit hit
- Document multi-entry backtest usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c33e588e7883209f735be35d18ec0d