### PR TITLE
Add portfolio runner and enhanced metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,27 @@ Artifacts:
     • artifacts/trades.ndjson – one capsule per trade
     • artifacts/session_summary.json – total trades + cumulative R
 
+### Portfolio mode (multi-symbol)
+```bash
+python -m src.portfolio_runner \
+  --csv ES:data/sample_ohlcv.csv \
+  --csv NQ:data/sample_ohlcv.csv \
+  --csv CL:data/sample_ohlcv.csv \
+  --max-trades 8 --dd-r -5 --cooldown 10 --lookahead 64
+```
+
+Artifacts:
+    • artifacts/<SYMBOL>/trades.ndjson – per-symbol capsules
+    • artifacts/portfolio_summary.json – aggregate trades + net_R and per-symbol metrics
+
+---
+
+## Why this matters
+- **Portfolio reality**: you can now test ES/NQ/CL together with per-symbol guardrails.
+- **Metrics panel**: supports both legacy PnL capsules and the new R-based capsules.
+- **CI-safe**: tiny tests + no network calls; works on vanilla runners.
+
+If you want the next slice, I’ll add:
+- **Expectancy table** (avg win R, avg loss R, payoff ratio)
+- **A/B strategy toggles** (collapse ⟿ vs. recovery ☑ mean-reversion) with a comparison report.
+

--- a/src/metrics.py
+++ b/src/metrics.py
@@ -4,7 +4,8 @@ from typing import List, Dict
 
 
 def load_trades(ndjson_path: str) -> List[Dict]:
-    if not os.path.exists(ndjson_path): return []
+    if not os.path.exists(ndjson_path):
+        return []
     out = []
     with open(ndjson_path, "r", encoding="utf-8") as f:
         for line in f:
@@ -15,19 +16,41 @@ def load_trades(ndjson_path: str) -> List[Dict]:
 
 
 def compute_metrics(trades: List[Dict]) -> Dict:
-    pnl = [t.get("pnl", 0.0) for t in trades]
-    wins = sum(1 for x in pnl if x > 0)
-    losses = sum(1 for x in pnl if x <= 0)
-    eq = 0.0; peak = 0.0; maxdd = 0.0
+    """Supports either PnL-based or R-multiple-based capsules."""
+    pnl = []
+    rvals = []
+    for t in trades:
+        if "pnl" in t:
+            pnl.append(float(t.get("pnl", 0.0)))
+        v = t.get("verdict", {})
+        if isinstance(v, dict) and "R" in v:
+            try:
+                rvals.append(float(v["R"]))
+            except Exception:
+                pass
+
+    # Equity curve for maxDD
+    eq = 0.0
+    peak = 0.0
+    maxdd = 0.0
     for x in pnl:
         eq += x
         peak = max(peak, eq)
         maxdd = min(maxdd, eq - peak)
+
+    wins = sum(1 for x in rvals if x > 0)
+    losses = sum(1 for x in rvals if x <= 0)
+    win_rate = (wins / len(rvals)) if rvals else 0.0
+    expectancy_R = (sum(rvals) / len(rvals)) if rvals else 0.0
+
     return {
-        "trades": len(pnl),
-        "wins": wins, "losses": losses,
-        "win_rate": (wins / len(pnl)) if pnl else 0.0,
-        "net_pnl": sum(pnl),
-        "max_drawdown": maxdd
+        "count": len(trades),
+        "pnl_sum": sum(pnl) if pnl else 0.0,
+        "max_drawdown": maxdd,
+        "wins": wins,
+        "losses": losses,
+        "win_rate": win_rate,
+        "cum_R": sum(rvals) if rvals else 0.0,
+        "avg_R": expectancy_R,
     }
 

--- a/src/portfolio_runner.py
+++ b/src/portfolio_runner.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+import argparse, json, os
+import pandas as pd
+from typing import Dict
+from .risk import RiskParams
+from .policy import DayPolicy
+from .scanner import multi_entry_scan
+from .metrics import load_trades, compute_metrics
+
+
+def load_csv(path: str) -> pd.DataFrame:
+    df = pd.read_csv(path)
+    if "timestamp" in df.columns:
+        df["timestamp"] = pd.to_datetime(df["timestamp"])
+        df = df.set_index("timestamp")
+    return df
+
+
+def parse_symbol_map(pairs: list[str]) -> Dict[str, str]:
+    out: Dict[str, str] = {}
+    for p in pairs:
+        if ":" not in p:
+            raise ValueError(f"--csv expects SYMBOL:path.csv, got {p}")
+        sym, path = p.split(":", 1)
+        out[sym.strip()] = path.strip()
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Portfolio multi-entry backtest")
+    ap.add_argument("--csv", action="append", required=True,
+                    help="SYMBOL:path.csv (repeatable). Example: --csv ES:data/es.csv --csv NQ:data/nq.csv")
+    ap.add_argument("--atr", type=int, default=14)
+    ap.add_argument("--lookahead", type=int, default=64)
+    ap.add_argument("--cooldown", type=int, default=10)
+    ap.add_argument("--max-trades", type=int, default=8)
+    ap.add_argument("--dd-r", type=float, default=-5.0)
+    ap.add_argument("--risk-pct", type=float, default=0.016)
+    ap.add_argument("--rr", type=float, default=2.5)
+    ap.add_argument("--atr-mult", type=float, default=1.5)
+    args = ap.parse_args()
+
+    symmap = parse_symbol_map(args.csv)
+    risk = RiskParams(risk_pct=args.risk_pct, rr=args.rr, atr_mult=args.atr_mult)
+    policy = DayPolicy(max_trades=args.max_trades, dd_limit_r=args.dd_r)
+
+    os.makedirs("artifacts", exist_ok=True)
+    portfolio = {}
+    net_R = 0.0
+    total_trades = 0
+
+    for sym, path in symmap.items():
+        df = load_csv(path)
+        outdir = f"artifacts/{sym}"
+        trades, cumR = multi_entry_scan(
+            df=df,
+            symbol=sym,
+            risk=risk,
+            outdir=outdir,                # per-symbol capsules
+            atr_period=args.atr,
+            look_ahead_bars=args.lookahead,
+            cooldown_bars=args.cooldown,
+            day_policy=policy,
+        )
+        # metrics per symbol
+        m = compute_metrics(load_trades(f"{outdir}/trades.ndjson"))
+        portfolio[sym] = {"trades": trades, "cumR": cumR, "metrics": m}
+        net_R += cumR
+        total_trades += trades
+
+    summary = {"symbols": list(symmap.keys()), "total_trades": total_trades, "net_R": net_R, "by_symbol": portfolio}
+    with open("artifacts/portfolio_summary.json", "w") as f:
+        json.dump(summary, f, indent=2)
+    print(f"[OK] Portfolio symbols={list(symmap.keys())} total_trades={total_trades} net_R={net_R:.2f}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tests/test_metrics_panel.py
+++ b/tests/test_metrics_panel.py
@@ -1,0 +1,15 @@
+from src.metrics import compute_metrics
+
+
+def test_metrics_from_R_only_capsules():
+    trades = [
+        {"verdict": {"R": 1.0}},
+        {"verdict": {"R": -0.5}},
+        {"verdict": {"R": 2.0}},
+    ]
+    m = compute_metrics(trades)
+    assert m["count"] == 3
+    assert abs(m["cum_R"] - 2.5) < 1e-9
+    assert m["wins"] == 2 and m["losses"] == 1
+    assert 0.0 <= m["win_rate"] <= 1.0
+


### PR DESCRIPTION
## Summary
- Implement portfolio runner to backtest multiple symbols and aggregate per-symbol metrics
- Expand metrics module to handle both PnL and R-based trade capsules
- Document multi-symbol portfolio mode and rationale in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3402ffc708320b950b3b02318fa24