### PR TITLE
Add A/B strategies with expectancy metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,14 +106,23 @@ Artifacts:
     • artifacts/<SYMBOL>/trades.ndjson – per-symbol capsules
     • artifacts/portfolio_summary.json – aggregate trades + net_R and per-symbol metrics
 
+### A/B compare (⟿ collapse vs ☑ recovery)
+```bash
+python -m src.ab_runner --csv data/sample_ohlcv.csv --symbol ES \
+  --rev-k 1.0 --ma 20 --max-trades 8 --dd-r -5 --cooldown 10
+```
+
+Outputs:
+    • artifacts/ES_A/ and artifacts/ES_B/ – per-strategy trade capsules
+    • artifacts/ab_summary.json – side-by-side cumR & trade counts
+
+Recovery mode: trades toward SMA when price deviates > k×ATR (default k=1.0) and glyph is ☑.
+
 ---
 
-## Why this matters
-- **Portfolio reality**: you can now test ES/NQ/CL together with per-symbol guardrails.
-- **Metrics panel**: supports both legacy PnL capsules and the new R-based capsules.
-- **CI-safe**: tiny tests + no network calls; works on vanilla runners.
-
-If you want the next slice, I’ll add:
-- **Expectancy table** (avg win R, avg loss R, payoff ratio)
-- **A/B strategy toggles** (collapse ⟿ vs. recovery ☑ mean-reversion) with a comparison report.
+## What you get right now
+- Toggleable **strategy modes** without touching the core engine
+- **Expectancy panel** (avg win R, avg loss R, payoff, profit factor, cumR)
+- A clean **A/B runner** to compare ideas quickly
+- CI stays green (pure-Python + tiny tests)
 

--- a/src/ab_runner.py
+++ b/src/ab_runner.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+import argparse, json, os
+import pandas as pd
+from .risk import RiskParams
+from .policy import DayPolicy
+from .scanner import multi_entry_scan
+
+def load_csv(path: str) -> pd.DataFrame:
+    df = pd.read_csv(path)
+    if "timestamp" in df.columns:
+        df["timestamp"] = pd.to_datetime(df["timestamp"])
+        df = df.set_index("timestamp")
+    return df
+
+def main():
+    ap = argparse.ArgumentParser(description="A/B compare collapse vs recovery strategies")
+    ap.add_argument("--csv", required=True)
+    ap.add_argument("--symbol", default="ES")
+    ap.add_argument("--atr", type=int, default=14)
+    ap.add_argument("--lookahead", type=int, default=64)
+    ap.add_argument("--cooldown", type=int, default=10)
+    ap.add_argument("--max-trades", type=int, default=8)
+    ap.add_argument("--dd-r", type=float, default=-5.0)
+    ap.add_argument("--risk-pct", type=float, default=0.016)
+    ap.add_argument("--rr", type=float, default=2.5)
+    ap.add_argument("--atr-mult", type=float, default=1.5)
+    ap.add_argument("--rev-k", type=float, default=1.0)
+    ap.add_argument("--ma", type=int, default=20)
+    args = ap.parse_args()
+
+    df = load_csv(args.csv)
+    outA = f"artifacts/{args.symbol}_A"
+    outB = f"artifacts/{args.symbol}_B"
+    risk = RiskParams(risk_pct=args.risk_pct, rr=args.rr, atr_mult=args.atr_mult)
+    policy = DayPolicy(max_trades=args.max_trades, dd_limit_r=args.dd_r)
+
+    tradesA, R_A = multi_entry_scan(df, args.symbol, risk, outdir=outA, atr_period=args.atr,
+                                    look_ahead_bars=args.lookahead, cooldown_bars=args.cooldown,
+                                    day_policy=policy, mode="collapse")
+    tradesB, R_B = multi_entry_scan(df, args.symbol, risk, outdir=outB, atr_period=args.atr,
+                                    look_ahead_bars=args.lookahead, cooldown_bars=args.cooldown,
+                                    day_policy=policy, mode="recovery", rev_k=args.rev_k, ma_period=args.ma)
+
+    os.makedirs("artifacts", exist_ok=True)
+    with open("artifacts/ab_summary.json", "w") as f:
+        json.dump({"symbol": args.symbol,
+                   "A_collapse": {"trades": tradesA, "cumR": R_A},
+                   "B_recovery": {"trades": tradesB, "cumR": R_B}}, f, indent=2)
+    print(f"[A/B] collapse: trades={tradesA} cumR={R_A:.2f} | recovery: trades={tradesB} cumR={R_B:.2f}")
+
+if __name__ == "__main__":
+    main()

--- a/src/indicators.py
+++ b/src/indicators.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+import numpy as np
+
+def sma(x: np.ndarray, period: int) -> np.ndarray:
+    period = max(1, min(period, x.size))
+    k = np.ones(period) / period
+    y = np.convolve(x, k, mode="same")
+    # warmup stabilize
+    y[:period] = np.maximum.accumulate(y[:period])
+    return y

--- a/src/metrics.py
+++ b/src/metrics.py
@@ -43,14 +43,23 @@ def compute_metrics(trades: List[Dict]) -> Dict:
     win_rate = (wins / len(rvals)) if rvals else 0.0
     expectancy_R = (sum(rvals) / len(rvals)) if rvals else 0.0
 
+    pos = [x for x in rvals if x > 0]
+    neg = [x for x in rvals if x <= 0]
+    avg_win = sum(pos) / len(pos) if pos else 0.0
+    avg_loss = sum(neg) / len(neg) if neg else 0.0  # negative or zero
+    payoff = (avg_win / abs(avg_loss)) if avg_loss < 0 else 0.0
+    profit_factor = (sum(pos) / abs(sum(neg))) if neg and sum(neg) < 0 else (sum(pos) if pos else 0.0)
+
     return {
         "count": len(trades),
         "pnl_sum": sum(pnl) if pnl else 0.0,
         "max_drawdown": maxdd,
-        "wins": wins,
-        "losses": losses,
-        "win_rate": win_rate,
+        "wins": wins, "losses": losses, "win_rate": win_rate,
         "cum_R": sum(rvals) if rvals else 0.0,
         "avg_R": expectancy_R,
+        "avg_win_R": avg_win,
+        "avg_loss_R": avg_loss,
+        "payoff_ratio": payoff,
+        "profit_factor_R": profit_factor,
     }
 

--- a/src/strategies.py
+++ b/src/strategies.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+import numpy as np
+from typing import Literal
+from .indicators import sma
+
+Mode = Literal["collapse", "recovery"]
+
+def collapse_side(close: np.ndarray, lookback: int = 20) -> str:
+    if close.size <= lookback:
+        return "wait"
+    return "long" if close[-1] > close[-lookback] else "short"
+
+def recovery_side(close: np.ndarray, atr_val: float, k: float = 1.0, ma_period: int = 20) -> str:
+    """
+    Mean-reversion toward SMA. If price is > k*ATR above SMA → short, below → long.
+    """
+    if close.size < ma_period:
+        return "wait"
+    ma = sma(close, ma_period)[-1]
+    px = float(close[-1])
+    if px >= ma + k * atr_val:
+        return "short"
+    if px <= ma - k * atr_val:
+        return "long"
+    return "wait"
+
+def entry_side(mode: Mode, close: np.ndarray, atr_val: float, **kw) -> str:
+    if mode == "collapse":
+        lb = int(kw.get("lookback", 20))
+        return collapse_side(close, lb)
+    else:
+        k = float(kw.get("k", 1.0))
+        ma = int(kw.get("ma_period", 20))
+        return recovery_side(close, atr_val, k=k, ma_period=ma)

--- a/tests/test_expectancy.py
+++ b/tests/test_expectancy.py
@@ -1,0 +1,10 @@
+from src.metrics import compute_metrics
+
+
+def test_expectancy_panel():
+    trades = [{"verdict": {"R": r}} for r in [1.0, 2.0, -1.0, -0.5]]
+    m = compute_metrics(trades)
+    assert round(m["cum_R"], 3) == 1.5
+    assert m["wins"] == 2 and m["losses"] == 2
+    assert m["avg_win_R"] > 0 and m["avg_loss_R"] < 0
+    assert m["payoff_ratio"] > 0


### PR DESCRIPTION
## Summary
- add SMA helper and strategy selectors for collapse vs recovery modes
- extend scanner and metrics to support expectancy panel
- introduce A/B runner and docs for comparing strategy modes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c343f29f3083209de2e9db8905f2a9