### PR TITLE
Add walk-forward evaluation runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,40 @@ Outputs:
 
 Recovery mode: trades toward SMA when price deviates > k×ATR (default k=1.0) and glyph is ☑.
 
+### Walk-Forward Evaluation (rolling OOS)
+Evaluate the strategy on rolling out-of-sample windows.
+
+```bash
+python -m src.wf_runner \
+  --csv data/sample_ohlcv.csv \
+  --symbol ES \
+  --mode collapse \
+  --test-bars 500 --step-bars 250 \
+  --max-trades 8 --dd-r -5 --cooldown 10
+```
+
+Artifacts:
+    • artifacts/wf/split_XX/ — per-split trade capsules
+    • artifacts/wf/wf_summary.json — {splits, total_trades, net_R, by_split:[...]}
+
+Tip: run both modes to compare stability over time:
+
+```bash
+python -m src.wf_runner --csv data/sample_ohlcv.csv --symbol ES --mode recovery
+```
+
+---
+
+## Why this helps
+- Gives you a **time-robust** view of collapse (⟿) vs. recovery (☑) behavior.
+- Clean separation of **in-sample** (unused for now) and **out-of-sample** windows.
+- Produces **per-split capsules** that match your existing analytics workflow.
+
+Want the next brick after this? Options:
+1) **Single-file HTML report** from artifacts (metrics table + split summary).
+2) **Parameter sweep** (grid over `rev_k`, `atr_period`, `rr`) with a leaderboard.
+3) **Paper-trade adapter** (CCXT / broker sim) behind a `--live` flag (stubbed in CI).
+
 ---
 
 ## What you get right now

--- a/src/walkforward.py
+++ b/src/walkforward.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import List, Tuple, Dict
+import os, json
+import pandas as pd
+from .risk import RiskParams
+from .policy import DayPolicy
+from .scanner import multi_entry_scan
+
+
+@dataclass
+class WFSpec:
+    train_bars: int = 0      # reserved for future tuning; ignored for now
+    test_bars: int = 500     # OOS length per split
+    step_bars: int = 250     # how far to advance between splits
+
+def rolling_windows(n_bars: int, spec: WFSpec) -> List[Tuple[int,int,int,int]]:
+    """
+    Produce (train_start, train_end, test_start, test_end) index tuples.
+    train_* are placeholders (0..train_end), test_* is the OOS slice we evaluate.
+    """
+    wins: List[Tuple[int,int,int,int]] = []
+    t, k, s = spec.train_bars, spec.test_bars, spec.step_bars
+    start = 0
+    while True:
+        train_start = max(0, start)
+        train_end   = max(0, start + t)           # currently not used
+        test_start  = train_end
+        test_end    = min(n_bars, test_start + k)
+        if test_end - test_start < k:             # not enough bars to evaluate
+            break
+        wins.append((train_start, train_end, test_start, test_end))
+        start = test_start + s
+        if start + t + k >= n_bars:
+            break
+    return wins
+
+def evaluate_walkforward(
+    df: pd.DataFrame,
+    symbol: str,
+    outdir: str,
+    wf: WFSpec,
+    mode: str,                      # "collapse" or "recovery"
+    risk: RiskParams,
+    look_ahead_bars: int = 64,
+    cooldown_bars: int = 10,
+    day_policy: DayPolicy = DayPolicy(),
+    rev_k: float = 1.0,
+    ma_period: int = 20,
+) -> Dict:
+    os.makedirs(outdir, exist_ok=True)
+    splits = rolling_windows(len(df), wf)
+    results = []
+    net_R = 0.0
+    total_trades = 0
+
+    for i, (tr_s, tr_e, te_s, te_e) in enumerate(splits, start=1):
+        # NOTE: we only evaluate on test window [te_s:te_e]
+        dfi = df.iloc[te_s:te_e].copy()
+        sym_out = os.path.join(outdir, f"split_{i:02d}")
+        os.makedirs(sym_out, exist_ok=True)
+        trades, cumR = multi_entry_scan(
+            df=dfi,
+            symbol=symbol,
+            risk=risk,
+            outdir=sym_out,
+            atr_period=14,
+            look_ahead_bars=look_ahead_bars,
+            cooldown_bars=cooldown_bars,
+            day_policy=DayPolicy(max_trades=day_policy.max_trades, dd_limit_r=day_policy.dd_limit_r),
+            mode="collapse" if mode == "collapse" else "recovery",
+            rev_k=rev_k,
+            ma_period=ma_period,
+        )
+        total_trades += trades
+        net_R += cumR
+        results.append({"split": i, "bars": int(te_e - te_s), "trades": trades, "cumR": cumR})
+
+    summary = {"mode": mode, "splits": len(splits), "total_trades": total_trades, "net_R": net_R, "by_split": results}
+    with open(os.path.join(outdir, "wf_summary.json"), "w") as f:
+        json.dump(summary, f, indent=2)
+    return summary

--- a/src/wf_runner.py
+++ b/src/wf_runner.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+import argparse
+import pandas as pd
+from .walkforward import WFSpec, evaluate_walkforward
+from .risk import RiskParams
+from .policy import DayPolicy
+
+
+def load_csv(path: str) -> pd.DataFrame:
+    df = pd.read_csv(path)
+    if "timestamp" in df.columns:
+        df["timestamp"] = pd.to_datetime(df["timestamp"])
+        df = df.set_index("timestamp")
+    return df
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Walk-forward evaluator")
+    ap.add_argument("--csv", required=True)
+    ap.add_argument("--symbol", default="ES")
+    ap.add_argument("--mode", choices=["collapse", "recovery"], default="collapse")
+    ap.add_argument("--test-bars", type=int, default=500)
+    ap.add_argument("--step-bars", type=int, default=250)
+    ap.add_argument("--max-trades", type=int, default=8)
+    ap.add_argument("--dd-r", type=float, default=-5.0)
+    ap.add_argument("--risk-pct", type=float, default=0.016)
+    ap.add_argument("--rr", type=float, default=2.5)
+    ap.add_argument("--atr-mult", type=float, default=1.5)
+    ap.add_argument("--lookahead", type=int, default=64)
+    ap.add_argument("--cooldown", type=int, default=10)
+    ap.add_argument("--rev-k", type=float, default=1.0)
+    ap.add_argument("--ma", type=int, default=20)
+    args = ap.parse_args()
+
+    df = load_csv(args.csv)
+    spec = WFSpec(train_bars=0, test_bars=args.test_bars, step_bars=args.step_bars)
+
+    risk = RiskParams(risk_pct=args.risk_pct, rr=args.rr, atr_mult=args.atr_mult)
+    dayp = DayPolicy(max_trades=args.max_trades, dd_limit_r=args.dd_r)
+
+    out = evaluate_walkforward(
+        df=df, symbol=args.symbol, outdir="artifacts/wf",
+        wf=spec, mode=args.mode, risk=risk,
+        look_ahead_bars=args.lookahead, cooldown_bars=args.cooldown,
+        day_policy=dayp, rev_k=args.rev_k, ma_period=args.ma
+    )
+    print(f"[WF] splits={out['splits']} total_trades={out['total_trades']} net_R={out['net_R']:.2f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_walk_splits.py
+++ b/tests/test_walk_splits.py
@@ -1,0 +1,9 @@
+from src.walkforward import WFSpec, rolling_windows
+
+def test_rolling_windows_count():
+    spec = WFSpec(train_bars=0, test_bars=50, step_bars=25)
+    wins = rolling_windows(200, spec)  # 200 bars total
+    # windows: [0..50), [25..75), [50..100), [75..125), [100..150), [125..175)
+    assert len(wins) == 6
+    # each window's test span length == 50
+    assert all((te - ts) == 50 for (_, _, ts, te) in wins)


### PR DESCRIPTION
## Summary
- implement walk-forward evaluation with rolling windows and per-split metrics
- provide command-line runner for the walk-forward evaluator
- document new runner in README and test rolling-window splits

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3460fe6b88320b1701f536e3fd562